### PR TITLE
Update behaviour of private groups for cloning and comments.

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -26,7 +26,7 @@
     padding: 1em;
     margin-bottom: 0.5em;
     margin-top: 0.5em;
-    span.collapse-toggle {
+    span.collapse-toggle, span.private-icon {
       margin-right: 0.2em;
       margin-left: 0.25em;
       i {
@@ -34,6 +34,9 @@
         top: 0.25em;
         cursor: pointer;
       }
+    }
+    span.private-icon i {
+      cursor: default;
     }
     a.link {
       text-align: center;

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,6 +19,7 @@ class GroupsController < ApplicationController
     @group = current_user.groups.find(params[:id])
     @group.assign_attributes(group_params)
     @group.save
+    @group.clones.destroy_all if @group.private?
   end
 
   def index
@@ -34,7 +35,7 @@ class GroupsController < ApplicationController
   def clone_toggle
     @group = Group.find(params[:id])
     if !current_user.cloned_groups.include?(@group)
-      Clone.create(:user_id => current_user.id, :group_id => @group.id)
+      Clone.create(:user_id => current_user.id, :group_id => @group.id) if !@group.private? && !current_user.groups.include?(@group)
     else
       Clone.find_by_user_id_and_group_id(current_user.id, @group.id).destroy
     end

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -1,5 +1,6 @@
-.row-fluid.comment
-  = form_for [group, comment], :remote => true, :html => { :class => 'form-inline' } do |f|
-    .span11.offset2
-      = f.text_field :body, :class => 'span9', :id => "comment_text_field#{group.id}"
-      = f.submit "#{action_name == 'edit' ? "Update " : ""}Comment", :class => 'btn btn-primary'
+- unless group.private?
+  .row-fluid.comment
+    = form_for [group, comment], :remote => true, :html => { :class => 'form-inline' } do |f|
+      .span11.offset2
+        = f.text_field :body, :class => 'span9', :id => "comment_text_field#{group.id}"
+        = f.submit "#{action_name == 'edit' ? "Update " : ""}Comment", :class => 'btn btn-primary'

--- a/app/views/dashboard/_group.html.haml
+++ b/app/views/dashboard/_group.html.haml
@@ -11,6 +11,8 @@
     %h2
       %span.collapse-toggle{ :data => { :collapsed => "#{group.collapsed?}" } }= icon_for(group.collapsed? ? 'plus-sign' : 'minus-sign')
       = show_group_as_link?(group, @user) ? (link_to group.title, group_links_path(group)) : group.title
+      - if group.private?
+        %span.private-icon{ :title => "Private Group" }= icon_for(:lock)
     .links{ :style => "#{group.collapsed? ? 'display: none' : ''}" }
       - group.links.order(:title).each do |link|
         = link_to link.title, link.href,


### PR DESCRIPTION
- Don't allow new comments for private groups
- Don't allow private groups to be cloned
- Delete clones when a private group becomes public
- Show lock icon beside private groups
